### PR TITLE
Update URL for cross compiler binaries

### DIFF
--- a/control/build.sh
+++ b/control/build.sh
@@ -21,7 +21,7 @@ install_packages() {
 }
 
 download_cross_compiler() {
-  url="http://landley.net/aboriginal/downloads/binaries/cross-compiler-i686.tar.bz2"
+  url="http://landley.net/code/firmware/downloads/binaries/cross-compiler-i686.tar.gz"
   archive=`basename "${url}"`
   log "Downloading cross compiler archive from ${url} to ${deuac_home}/${archive}"
   if [[ ! -e "${archive}" ]] && ! curl -L "${url}" -o "${archive}"
@@ -31,9 +31,9 @@ download_cross_compiler() {
 }
 
 extract_cross_compiler() {
-  cross_compiler=`basename "${archive}" .tar.bz2`
+  cross_compiler=`basename "${archive}" .tar.gz`
   log "Extracting cross compiler archive from ${archive} to ${deuac_home}/${cross_compiler}"
-  if [[ ! -e "${cross_compiler}" ]] && ! tar -jxf "${archive}"
+  if [[ ! -e "${cross_compiler}" ]] && ! tar -xzf "${archive}"
   then
     fail "Failed to extract ${archive} to ${deuac_home}/${cross_compiler} using 'tar', error code ($?)"
   fi


### PR DESCRIPTION
New URL taken from https://github.com/xdissent/ievms/pull/297/files
